### PR TITLE
Fix printing of embedded fields

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -598,12 +598,17 @@ func (pt PredeclaredType) String(map[string]string, string) string { return stri
 func (pt PredeclaredType) addImports(map[string]bool)              {}
 
 type Field struct {
-	Name string
-	Type Type
+	Name      string
+	Type      Type
+	Anonymous bool
 }
 
 func (f *Field) String(pm map[string]string, pkgOverride string) string {
-	return f.Name + " " + f.Type.String(pm, pkgOverride)
+	if f.Anonymous {
+		return f.Type.String(pm, pkgOverride)
+	} else {
+		return f.Name + " " + f.Type.String(pm, pkgOverride)
+	}
 }
 
 // StructType is a struct type.
@@ -885,8 +890,9 @@ func (pkg *Package) unnamedTypeFromType(t reflect.Type) (Type, error) {
 			}
 
 			m := &Field{
-				Name: ft.Name,
-				Type: typ,
+				Name:      ft.Name,
+				Type:      typ,
+				Anonymous: ft.Anonymous,
 			}
 
 			fields = append(fields, m)

--- a/reflect.go
+++ b/reflect.go
@@ -116,6 +116,18 @@ func runInDir(program []byte, dir string) (*model.PackedPkg, error) {
 
 		if modRoot != "" {
 			MustCopyFile(filepath.Join(modRoot, "go.mod"), filepath.Join(tmpDir, "go.mod"))
+
+			// To enable local development of model/model.go, uncomment the following lines
+			// f, err := os.OpenFile(filepath.Join(tmpDir, "go.mod"), os.O_APPEND|os.O_WRONLY, 0600)
+			// if err != nil {
+			// 	return nil, fmt.Errorf("failed to open go.mod for appending: %v", err)
+			// }
+			// defer f.Close()
+
+			// replaceDirective := "\n\nreplace github.com/github/depstubber => /Users/owen-mc/workspace/depstubber\n"
+			// if _, err := f.WriteString(replaceDirective); err != nil {
+			// 	return nil, fmt.Errorf("failed to append replace directive to go.mod: %v", err)
+			// }
 		}
 	}
 


### PR DESCRIPTION
A struct type like this
```
struct {
   A
}
```
was getting printed by depstubber as
```
struct {
  A A
}
```
This fixes that.

It was hard to test it locally because `model/model.go` is accessed from the github repo. I had to add some code after copying the go.mod file to add a redirection to it so that it uses the local copy. I have left this in, commented out, to make it easier to test this kind of changing in future.

Unfortunately I was not able to find any way to avoid printing promoted methods as if they were methods on the type itself. It seems this is deliberately not exposed in the `reflect` package.